### PR TITLE
Added snap package support

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: termtosvg
+version: '0.3.0+git' # just for humans, typically '1.2+git' or '1.3.2'
+summary: Record terminal sessions as SVG animations
+description: |
+  A Linux terminal recorder written in Python
+  which renders your command line sessions 
+  as standalone SVG animations.
+
+grade: stable
+confinement: strict
+
+apps:
+  termtosvg:
+    command: termtosvg
+    plugs:
+      - home
+
+parts:
+  termtosvg:
+    source: https://github.com/nbedos/termtosvg.git
+    plugin: python
+    python-version: python3
+    build-packages:
+      - python3-pip


### PR DESCRIPTION
Snap packages are application packages for Linux. 
I have added the configuration file `snapcraft.yaml` so that you can create snap packages for `termtosvg`. 

The main benefit for snap packages is that the tools are there for you to self-publish your software.

1. Once you accept this PR, you can visit https://build.snapcraft.io/ and set up `termtosvg` to build automatically on the build servers. 
2. Then, you can visit https://dashboard.snapcraft.io/ to fill in the details to publish.

Feel free to ask any questions about this!