### PR TITLE
Use `pip install --user` instead of `pip install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ recording such as [asciinema](https://github.com/asciinema/asciinema).
 ## Installation
 termtosvg is compatible with Python >= 3.5 and can be installed with pip:
 ```
-pip install termtosvg
+pip install --user termtosvg
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ recording such as [asciinema](https://github.com/asciinema/asciinema).
 ## Installation
 termtosvg is compatible with Python >= 3.5 and can be installed with pip:
 ```
-pip install --user termtosvg
+pip3 install --user termtosvg
 ```
 
 ## Usage


### PR DESCRIPTION
This makes pip installation work without requiring root privileges on Linux.