### PR TITLE
edit a sentence in README.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ More examples of recordings can be found [here](https://github.com/nbedos/termto
 ## Motivation
 I really like the clean look of SVG animations. I wanted to see
 how this solution would hold out against other terminal
-recorder such as [asciinema](https://github.com/asciinema/asciinema).
+recorders such as [asciinema](https://github.com/asciinema/asciinema).
 
 ## Installation
 termtosvg is compatible with Python >= 3.5 and can be installed with pip:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ line sessions as standalone SVG animations.
 More examples of recordings can be found [here](https://github.com/nbedos/termtosvg/blob/0.3.0/examples/examples.md)
 
 ## Motivation
-I really like the clean look of SVG animations and I wanted to see
-how this solution would hold out against other attempts at terminal
-recording such as [asciinema](https://github.com/asciinema/asciinema).
+I really like the clean look of SVG animations. I wanted to see
+how this solution would hold out against other terminal
+recorder such as [asciinema](https://github.com/asciinema/asciinema).
 
 ## Installation
 termtosvg is compatible with Python >= 3.5 and can be installed with pip:


### PR DESCRIPTION
- The sentence was broken down to convey one idea per sentence.
- "attempts at terminal recording" -> "terminal recorder"
   The use of the word "attempt" makes the sentence wordier. Also, using "attempt" implies that asciinema is not a proper terminal recorder. 