### PR TITLE
Specify minimum compatible Python 3.5 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Topic :: System :: Shells',
         'Topic :: Terminals'
     ],
+    python_requires='>=3.5',
     packages=['termtosvg'],
     package_data={
         '': [


### PR DESCRIPTION
Fixes: #47