### PR TITLE
 Add support for italic text rendering 

### DIFF
--- a/termtosvg/anim.py
+++ b/termtosvg/anim.py
@@ -37,7 +37,7 @@ _CharacterCell = namedtuple('_CharacterCell', ['text', 'color', 'background_colo
 _CharacterCell.__doc__ = 'Representation of a character cell'
 _CharacterCell.text.__doc__ = 'Text content of the cell'
 _CharacterCell.bold.__doc__ = 'Bold modificator flag'
-_CharacterCell.italics.__doc__ = 'Itaics modificator flag'
+_CharacterCell.italics.__doc__ = 'Italics modificator flag'
 _CharacterCell.color.__doc__ = 'Color of the text'
 _CharacterCell.background_color.__doc__ = 'Background color of the cell'
 
@@ -184,7 +184,7 @@ def _render_characters(screen_line, cell_width):
     :param screen_line: Mapping between column numbers and characters
     :param cell_width: Width of a character cell in pixels
     """
-    line = [(col, char) for (col, char) in sorted(screen_line.items())]
+    line = sorted(screen_line.items())
     key = ConsecutiveWithSameAttributes(['color', 'bold', 'italics'])
     text_tags = [make_text_tag(column, attributes, ''.join(c.text for _, c in group), cell_width)
                  for (column, attributes), group in groupby(line, key)]

--- a/termtosvg/anim.py
+++ b/termtosvg/anim.py
@@ -33,10 +33,11 @@ class TemplateError(Exception):
     pass
 
 
-_CharacterCell = namedtuple('_CharacterCell', ['text', 'color', 'background_color', 'bold'])
+_CharacterCell = namedtuple('_CharacterCell', ['text', 'color', 'background_color', 'bold', 'italics'])
 _CharacterCell.__doc__ = 'Representation of a character cell'
 _CharacterCell.text.__doc__ = 'Text content of the cell'
 _CharacterCell.bold.__doc__ = 'Bold modificator flag'
+_CharacterCell.italics.__doc__ = 'Itaics modificator flag'
 _CharacterCell.color.__doc__ = 'Color of the text'
 _CharacterCell.background_color.__doc__ = 'Background color of the cell'
 
@@ -79,7 +80,7 @@ class CharacterCell(_CharacterCell):
         if char.reverse:
             text_color, background_color = background_color, text_color
 
-        return CharacterCell(char.data, text_color, background_color, char.bold)
+        return CharacterCell(char.data, text_color, background_color, char.bold, char.italics)
 
 
 CharacterCellConfig = namedtuple('CharacterCellConfig', ['width', 'height'])
@@ -157,6 +158,9 @@ def make_text_tag(column, attributes, text, cell_width):
     }
     if attributes['bold']:
         text_tag_attributes['font-weight'] = 'bold'
+    
+    if attributes['italics']:
+        text_tag_attributes['font-style'] = 'italic'
 
     if attributes['color'].startswith('#'):
         text_tag_attributes['fill'] = attributes['color']
@@ -181,7 +185,7 @@ def _render_characters(screen_line, cell_width):
     :param cell_width: Width of a character cell in pixels
     """
     line = [(col, char) for (col, char) in sorted(screen_line.items())]
-    key = ConsecutiveWithSameAttributes(['color', 'bold'])
+    key = ConsecutiveWithSameAttributes(['color', 'bold', 'italics'])
     text_tags = [make_text_tag(column, attributes, ''.join(c.text for _, c in group), cell_width)
                  for (column, attributes), group in groupby(line, key)]
 

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -27,16 +27,19 @@ class TestAnim(unittest.TestCase):
             pyte.screens.Char('F', '008700', 'ABCDEF'),
             # Bright and bold
             pyte.screens.Char('G', 'brightgreen', 'ABCDEF', bold=True),
+            # Italics
+            pyte.screens.Char('H', 'red', 'blue', italics=True),
         ]
 
         char_cells = [
-            anim.CharacterCell('A', 'color1', 'color4', False),
-            anim.CharacterCell('B', 'color4', 'color1', False),
-            anim.CharacterCell('C', 'color9', 'color4', True),
-            anim.CharacterCell('D', 'color4', 'color9', True),
-            anim.CharacterCell('E', 'foreground', 'background', False),
-            anim.CharacterCell('F', '#008700', '#ABCDEF', False),
-            anim.CharacterCell('G', 'color10', '#ABCDEF', True),
+            anim.CharacterCell('A', 'color1', 'color4', False, False),
+            anim.CharacterCell('B', 'color4', 'color1', False, False),
+            anim.CharacterCell('C', 'color9', 'color4', True, False),
+            anim.CharacterCell('D', 'color4', 'color9', True, False),
+            anim.CharacterCell('E', 'foreground', 'background', False, False),
+            anim.CharacterCell('F', '#008700', '#ABCDEF', False, False),
+            anim.CharacterCell('G', 'color10', '#ABCDEF', True, False),
+            anim.CharacterCell('H', 'color1', 'color4', False, True),
         ]
 
         for pyte_char, cell_char in zip(pyte_chars, char_cells):
@@ -46,16 +49,16 @@ class TestAnim(unittest.TestCase):
     def test__render_line_bg_colors_xml(self):
         cell_width = 8
         screen_line = {
-            0: anim.CharacterCell('A', 'black', 'red', False),
-            1: anim.CharacterCell('A', 'black', 'red', False),
-            3: anim.CharacterCell('A', 'black', 'red', False),
-            4: anim.CharacterCell('A', 'black', 'blue', False),
-            6: anim.CharacterCell('A', 'black', 'blue', False),
-            7: anim.CharacterCell('A', 'black', 'blue', False),
-            8: anim.CharacterCell('A', 'black', 'green', False),
-            9: anim.CharacterCell('A', 'black', 'red', False),
-            10: anim.CharacterCell('A', 'black', 'red', False),
-            11: anim.CharacterCell('A', 'black', '#123456', False),
+            0: anim.CharacterCell('A', 'black', 'red', False, False),
+            1: anim.CharacterCell('A', 'black', 'red', False, False),
+            3: anim.CharacterCell('A', 'black', 'red', False, False),
+            4: anim.CharacterCell('A', 'black', 'blue', False, False),
+            6: anim.CharacterCell('A', 'black', 'blue', False, False),
+            7: anim.CharacterCell('A', 'black', 'blue', False, False),
+            8: anim.CharacterCell('A', 'black', 'green', False, False),
+            9: anim.CharacterCell('A', 'black', 'red', False, False),
+            10: anim.CharacterCell('A', 'black', 'red', False, False),
+            11: anim.CharacterCell('A', 'black', '#123456', False, False),
         }
 
         rectangles = anim._render_line_bg_colors(screen_line=screen_line,
@@ -85,15 +88,15 @@ class TestAnim(unittest.TestCase):
 
     def test__render_characters(self):
         screen_line = {
-            0: anim.CharacterCell('A', 'red', 'white', False),
-            1: anim.CharacterCell('B', 'blue', 'white', False),
-            2: anim.CharacterCell('C', 'blue', 'white', False),
-            7: anim.CharacterCell('D', '#00FF00', 'white', False),
-            8: anim.CharacterCell('E', '#00FF00', 'white', False),
-            9: anim.CharacterCell('F', '#00FF00', 'white', False),
-            10: anim.CharacterCell('G', '#00FF00', 'white', False),
-            11: anim.CharacterCell('H', 'red', 'white', False),
-            20: anim.CharacterCell(' ', 'black', 'black', False)
+            0: anim.CharacterCell('A', 'red', 'white', False, False),
+            1: anim.CharacterCell('B', 'blue', 'white', False, False),
+            2: anim.CharacterCell('C', 'blue', 'white', False, False),
+            7: anim.CharacterCell('D', '#00FF00', 'white', False, False),
+            8: anim.CharacterCell('E', '#00FF00', 'white', False, False),
+            9: anim.CharacterCell('F', '#00FF00', 'white', False, False),
+            10: anim.CharacterCell('G', '#00FF00', 'white', False, False),
+            11: anim.CharacterCell('H', 'red', 'white', False, False),
+            20: anim.CharacterCell(' ', 'black', 'black', False, False)
         }
 
         with self.subTest(case='Content'):
@@ -141,7 +144,7 @@ class TestAnim(unittest.TestCase):
 
     def test_make_animated_group(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False) for c in 'line{}'.format(i)]
+            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False) for c in 'line{}'.format(i)]
             return dict(enumerate(chars))
 
         records = [
@@ -162,7 +165,7 @@ class TestAnim(unittest.TestCase):
 
     def test__render_animation(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False) for c in 'line{}'.format(i)]
+            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False) for c in 'line{}'.format(i)]
             return dict(enumerate(chars))
 
         records = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,8 +15,10 @@ SHELL_COMMANDS = [
     'a',
     'm',
     'i\r\n',
-    "\033[1;31mbright red fg\033[0m\r\n",
-    "\033[1;41mbright red bg\033[0m\r\n",
+    'echo -e "\\033[1;31mbright red fg\\033[0m"\r\n',
+    'echo -e "\\033[1;41mbright red bg\\033[0m"\r\n',
+    'echo -e "\\033[1mbold\\033[0m"\r\n',
+    'echo -e "\\033[3mitalics\\033[0m"\r\n',
     'exit;\r\n'
 ]
 


### PR DESCRIPTION
Added support for italic text rendering. I looked at how bold text rendering was done, and did italics the same way.

Example:
![termtosvg italics](https://rawgit.com/nnist/2dfbfc784097dc26e64fe692d35923d9/raw/e8b71e092d8f5c647335f962c7a86c38b1c05fe5/termtosvg_italics.svg?sanitize=true)