### PR TITLE
Add underscore and strikethrough text rendering support

### DIFF
--- a/termtosvg/anim.py
+++ b/termtosvg/anim.py
@@ -33,7 +33,10 @@ class TemplateError(Exception):
     pass
 
 
-_CharacterCell = namedtuple('_CharacterCell', ['text', 'color', 'background_color', 'bold', 'italics', 'underscore', 'strikethrough'])
+_CharacterCell = namedtuple('_CharacterCell', ['text', 'color',
+                                               'background_color', 'bold',
+                                               'italics', 'underscore',
+                                               'strikethrough'])
 _CharacterCell.__doc__ = 'Representation of a character cell'
 _CharacterCell.text.__doc__ = 'Text content of the cell'
 _CharacterCell.bold.__doc__ = 'Bold modificator flag'
@@ -82,7 +85,9 @@ class CharacterCell(_CharacterCell):
         if char.reverse:
             text_color, background_color = background_color, text_color
 
-        return CharacterCell(char.data, text_color, background_color, char.bold, char.italics, char.underscore, char.strikethrough)
+        return CharacterCell(char.data, text_color, background_color,
+                             char.bold, char.italics, char.underscore,
+                             char.strikethrough)
 
 
 CharacterCellConfig = namedtuple('CharacterCellConfig', ['width', 'height'])

--- a/termtosvg/anim.py
+++ b/termtosvg/anim.py
@@ -33,12 +33,13 @@ class TemplateError(Exception):
     pass
 
 
-_CharacterCell = namedtuple('_CharacterCell', ['text', 'color', 'background_color', 'bold', 'italics', 'underscore'])
+_CharacterCell = namedtuple('_CharacterCell', ['text', 'color', 'background_color', 'bold', 'italics', 'underscore', 'strikethrough'])
 _CharacterCell.__doc__ = 'Representation of a character cell'
 _CharacterCell.text.__doc__ = 'Text content of the cell'
 _CharacterCell.bold.__doc__ = 'Bold modificator flag'
 _CharacterCell.italics.__doc__ = 'Italics modificator flag'
 _CharacterCell.underscore.__doc__ = 'Underscore modificator flag'
+_CharacterCell.strikethrough.__doc__ = 'Strikethrough modificator flag'
 _CharacterCell.color.__doc__ = 'Color of the text'
 _CharacterCell.background_color.__doc__ = 'Background color of the cell'
 
@@ -81,7 +82,7 @@ class CharacterCell(_CharacterCell):
         if char.reverse:
             text_color, background_color = background_color, text_color
 
-        return CharacterCell(char.data, text_color, background_color, char.bold, char.italics, char.underscore)
+        return CharacterCell(char.data, text_color, background_color, char.bold, char.italics, char.underscore, char.strikethrough)
 
 
 CharacterCellConfig = namedtuple('CharacterCellConfig', ['width', 'height'])
@@ -163,9 +164,13 @@ def make_text_tag(column, attributes, text, cell_width):
     if attributes['italics']:
         text_tag_attributes['font-style'] = 'italic'
 
+    decoration = ''
     if attributes['underscore']:
-        text_tag_attributes['text-decoration'] = 'underline'
-    
+        decoration = 'underline'
+    if attributes['strikethrough']:
+        decoration += ' line-through'
+    text_tag_attributes['text-decoration'] = decoration
+
     if attributes['color'].startswith('#'):
         text_tag_attributes['fill'] = attributes['color']
     else:
@@ -189,7 +194,7 @@ def _render_characters(screen_line, cell_width):
     :param cell_width: Width of a character cell in pixels
     """
     line = sorted(screen_line.items())
-    key = ConsecutiveWithSameAttributes(['color', 'bold', 'italics', 'underscore'])
+    key = ConsecutiveWithSameAttributes(['color', 'bold', 'italics', 'underscore', 'strikethrough'])
     text_tags = [make_text_tag(column, attributes, ''.join(c.text for _, c in group), cell_width)
                  for (column, attributes), group in groupby(line, key)]
 

--- a/termtosvg/anim.py
+++ b/termtosvg/anim.py
@@ -33,10 +33,11 @@ class TemplateError(Exception):
     pass
 
 
-_CharacterCell = namedtuple('_CharacterCell', ['text', 'color', 'background_color', 'bold'])
+_CharacterCell = namedtuple('_CharacterCell', ['text', 'color', 'background_color', 'bold', 'underscore'])
 _CharacterCell.__doc__ = 'Representation of a character cell'
 _CharacterCell.text.__doc__ = 'Text content of the cell'
 _CharacterCell.bold.__doc__ = 'Bold modificator flag'
+_CharacterCell.underscore.__doc__ = 'Underscore modificator flag'
 _CharacterCell.color.__doc__ = 'Color of the text'
 _CharacterCell.background_color.__doc__ = 'Background color of the cell'
 
@@ -79,7 +80,7 @@ class CharacterCell(_CharacterCell):
         if char.reverse:
             text_color, background_color = background_color, text_color
 
-        return CharacterCell(char.data, text_color, background_color, char.bold)
+        return CharacterCell(char.data, text_color, background_color, char.bold, char.underscore)
 
 
 CharacterCellConfig = namedtuple('CharacterCellConfig', ['width', 'height'])
@@ -158,6 +159,9 @@ def make_text_tag(column, attributes, text, cell_width):
     if attributes['bold']:
         text_tag_attributes['font-weight'] = 'bold'
 
+    if attributes['underscore']:
+        text_tag_attributes['text-decoration'] = 'underline'
+    
     if attributes['color'].startswith('#'):
         text_tag_attributes['fill'] = attributes['color']
     else:
@@ -181,7 +185,7 @@ def _render_characters(screen_line, cell_width):
     :param cell_width: Width of a character cell in pixels
     """
     line = [(col, char) for (col, char) in sorted(screen_line.items())]
-    key = ConsecutiveWithSameAttributes(['color', 'bold'])
+    key = ConsecutiveWithSameAttributes(['color', 'bold', 'underscore'])
     text_tags = [make_text_tag(column, attributes, ''.join(c.text for _, c in group), cell_width)
                  for (column, attributes), group in groupby(line, key)]
 

--- a/termtosvg/anim.py
+++ b/termtosvg/anim.py
@@ -37,6 +37,9 @@ _CharacterCell = namedtuple('_CharacterCell', ['text', 'color',
                                                'background_color', 'bold',
                                                'italics', 'underscore',
                                                'strikethrough'])
+# Make Last four arguments of _CharacterCell constructor default to False (bold, italics,
+# underscore and strikethrough)
+_CharacterCell.__new__.__defaults__ = (False,) * 4
 _CharacterCell.__doc__ = 'Representation of a character cell'
 _CharacterCell.text.__doc__ = 'Text content of the cell'
 _CharacterCell.bold.__doc__ = 'Bold modificator flag'
@@ -192,7 +195,7 @@ def _render_characters(screen_line, cell_width):
     # type: (Dict[int, CharacterCell], int) -> List[etree.ElementBase]
     """Return a list of 'text' elements representing the line of the screen
 
-    Consecutive characters with the same styling attributes (text color and font weight) are
+    Consecutive characters with the same styling attributes (text color, font weight...) are
     grouped together in a single text element.
 
     :param screen_line: Mapping between column numbers and characters

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -36,16 +36,26 @@ class TestAnim(unittest.TestCase):
         ]
 
         char_cells = [
-            anim.CharacterCell('A', 'color1', 'color4', False, False, False, False),
-            anim.CharacterCell('B', 'color4', 'color1', False, False, False, False),
-            anim.CharacterCell('C', 'color9', 'color4', True, False, False, False),
-            anim.CharacterCell('D', 'color4', 'color9', True, False, False, False),
-            anim.CharacterCell('E', 'foreground', 'background', False, False, False, False),
-            anim.CharacterCell('F', '#008700', '#ABCDEF', False, False, False, False),
-            anim.CharacterCell('G', 'color10', '#ABCDEF', True, False, False, False),
-            anim.CharacterCell('H', 'color1', 'color4', False, True, False, False),
-            anim.CharacterCell('I', 'color1', 'color4', False, False, True, False),
-            anim.CharacterCell('J', 'color1', 'color4', False, False, False, True),
+            anim.CharacterCell('A', 'color1', 'color4',
+                               False, False, False, False),
+            anim.CharacterCell('B', 'color4', 'color1',
+                               False, False, False, False),
+            anim.CharacterCell('C', 'color9', 'color4',
+                               True, False, False, False),
+            anim.CharacterCell('D', 'color4', 'color9',
+                               True, False, False, False),
+            anim.CharacterCell('E', 'foreground', 'background',
+                               False, False, False, False),
+            anim.CharacterCell('F', '#008700', '#ABCDEF',
+                               False, False, False, False),
+            anim.CharacterCell('G', 'color10', '#ABCDEF',
+                               True, False, False, False),
+            anim.CharacterCell('H', 'color1', 'color4',
+                               False, True, False, False),
+            anim.CharacterCell('I', 'color1', 'color4',
+                               False, False, True, False),
+            anim.CharacterCell('J', 'color1', 'color4',
+                               False, False, False, True),
         ]
 
         for pyte_char, cell_char in zip(pyte_chars, char_cells):
@@ -55,16 +65,26 @@ class TestAnim(unittest.TestCase):
     def test__render_line_bg_colors_xml(self):
         cell_width = 8
         screen_line = {
-            0: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
-            1: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
-            3: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
-            4: anim.CharacterCell('A', 'black', 'blue', False, False, False, False),
-            6: anim.CharacterCell('A', 'black', 'blue', False, False, False, False),
-            7: anim.CharacterCell('A', 'black', 'blue', False, False, False, False),
-            8: anim.CharacterCell('A', 'black', 'green', False, False, False, False),
-            9: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
-            10: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
-            11: anim.CharacterCell('A', 'black', '#123456', False, False, False, False),
+            0: anim.CharacterCell('A', 'black', 'red',
+                                  False, False, False, False),
+            1: anim.CharacterCell('A', 'black', 'red',
+                                  False, False, False, False),
+            3: anim.CharacterCell('A', 'black', 'red',
+                                  False, False, False, False),
+            4: anim.CharacterCell('A', 'black', 'blue',
+                                  False, False, False, False),
+            6: anim.CharacterCell('A', 'black', 'blue',
+                                  False, False, False, False),
+            7: anim.CharacterCell('A', 'black', 'blue',
+                                  False, False, False, False),
+            8: anim.CharacterCell('A', 'black', 'green',
+                                  False, False, False, False),
+            9: anim.CharacterCell('A', 'black', 'red',
+                                  False, False, False, False),
+            10: anim.CharacterCell('A', 'black', 'red',
+                                   False, False, False, False),
+            11: anim.CharacterCell('A', 'black', '#123456',
+                                   False, False, False, False),
         }
 
         rectangles = anim._render_line_bg_colors(screen_line=screen_line,
@@ -94,15 +114,24 @@ class TestAnim(unittest.TestCase):
 
     def test__render_characters(self):
         screen_line = {
-            0: anim.CharacterCell('A', 'red', 'white', False, False, False, False),
-            1: anim.CharacterCell('B', 'blue', 'white', False, False, False, False),
-            2: anim.CharacterCell('C', 'blue', 'white', False, False, False, False),
-            7: anim.CharacterCell('D', '#00FF00', 'white', False, False, False, False),
-            8: anim.CharacterCell('E', '#00FF00', 'white', False, False, False, False),
-            9: anim.CharacterCell('F', '#00FF00', 'white', False, False, False, False),
-            10: anim.CharacterCell('G', '#00FF00', 'white', False, False, False, False),
-            11: anim.CharacterCell('H', 'red', 'white', False, False, False, False),
-            20: anim.CharacterCell(' ', 'black', 'black', False, False, False, False)
+            0: anim.CharacterCell('A', 'red', 'white',
+                                  False, False, False, False),
+            1: anim.CharacterCell('B', 'blue', 'white',
+                                  False, False, False, False),
+            2: anim.CharacterCell('C', 'blue', 'white',
+                                  False, False, False, False),
+            7: anim.CharacterCell('D', '#00FF00', 'white',
+                                  False, False, False, False),
+            8: anim.CharacterCell('E', '#00FF00', 'white',
+                                  False, False, False, False),
+            9: anim.CharacterCell('F', '#00FF00', 'white',
+                                  False, False, False, False),
+            10: anim.CharacterCell('G', '#00FF00', 'white',
+                                   False, False, False, False),
+            11: anim.CharacterCell('H', 'red', 'white',
+                                   False, False, False, False),
+            20: anim.CharacterCell(' ', 'black', 'black',
+                                   False, False, False, False)
         }
 
         with self.subTest(case='Content'):
@@ -150,7 +179,10 @@ class TestAnim(unittest.TestCase):
 
     def test_make_animated_group(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False, False, False) for c in 'line{}'.format(i)]
+            chars = []
+            for c in 'line{}'.format(i):
+                chars.append(anim.CharacterCell(c, '#123456', '#789012',
+                                                False, False, False, False))
             return dict(enumerate(chars))
 
         records = [
@@ -171,7 +203,10 @@ class TestAnim(unittest.TestCase):
 
     def test__render_animation(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False, False, False) for c in 'line{}'.format(i)]
+            chars = []
+            for c in 'line{}'.format(i):
+                chars.append(anim.CharacterCell(c, '#123456', '#789012',
+                                                False, False, False, False))
             return dict(enumerate(chars))
 
         records = [

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -34,14 +34,15 @@ class TestAnim(unittest.TestCase):
         ]
 
         char_cells = [
-            anim.CharacterCell('A', 'color1', 'color4', False, False),
-            anim.CharacterCell('B', 'color4', 'color1', False, False),
-            anim.CharacterCell('C', 'color9', 'color4', True, False),
-            anim.CharacterCell('D', 'color4', 'color9', True, False),
-            anim.CharacterCell('E', 'foreground', 'background', False, False),
-            anim.CharacterCell('F', '#008700', '#ABCDEF', False, False),
-            anim.CharacterCell('G', 'color10', '#ABCDEF', True, False),
-            anim.CharacterCell('H', 'color1', 'color4', False, True),
+            anim.CharacterCell('A', 'color1', 'color4', False, False, False),
+            anim.CharacterCell('B', 'color4', 'color1', False, False, False),
+            anim.CharacterCell('C', 'color9', 'color4', True, False, False),
+            anim.CharacterCell('D', 'color4', 'color9', True, False, False),
+            anim.CharacterCell('E', 'foreground', 'background', False, False, False),
+            anim.CharacterCell('F', '#008700', '#ABCDEF', False, False, False),
+            anim.CharacterCell('G', 'color10', '#ABCDEF', True, False, False),
+            anim.CharacterCell('H', 'color1', 'color4', False, True, False),
+            anim.CharacterCell('I', 'color1', 'color4', False, False, True),
         ]
 
         for pyte_char, cell_char in zip(pyte_chars, char_cells):
@@ -51,16 +52,16 @@ class TestAnim(unittest.TestCase):
     def test__render_line_bg_colors_xml(self):
         cell_width = 8
         screen_line = {
-            0: anim.CharacterCell('A', 'black', 'red', False, False),
-            1: anim.CharacterCell('A', 'black', 'red', False, False),
-            3: anim.CharacterCell('A', 'black', 'red', False, False),
-            4: anim.CharacterCell('A', 'black', 'blue', False, False),
-            6: anim.CharacterCell('A', 'black', 'blue', False, False),
-            7: anim.CharacterCell('A', 'black', 'blue', False, False),
-            8: anim.CharacterCell('A', 'black', 'green', False, False),
-            9: anim.CharacterCell('A', 'black', 'red', False, False),
-            10: anim.CharacterCell('A', 'black', 'red', False, False),
-            11: anim.CharacterCell('A', 'black', '#123456', False, False),
+            0: anim.CharacterCell('A', 'black', 'red', False, False, False),
+            1: anim.CharacterCell('A', 'black', 'red', False, False, False),
+            3: anim.CharacterCell('A', 'black', 'red', False, False, False),
+            4: anim.CharacterCell('A', 'black', 'blue', False, False, False),
+            6: anim.CharacterCell('A', 'black', 'blue', False, False, False),
+            7: anim.CharacterCell('A', 'black', 'blue', False, False, False),
+            8: anim.CharacterCell('A', 'black', 'green', False, False, False),
+            9: anim.CharacterCell('A', 'black', 'red', False, False, False),
+            10: anim.CharacterCell('A', 'black', 'red', False, False, False),
+            11: anim.CharacterCell('A', 'black', '#123456', False, False, False),
         }
 
         rectangles = anim._render_line_bg_colors(screen_line=screen_line,
@@ -90,15 +91,15 @@ class TestAnim(unittest.TestCase):
 
     def test__render_characters(self):
         screen_line = {
-            0: anim.CharacterCell('A', 'red', 'white', False, False),
-            1: anim.CharacterCell('B', 'blue', 'white', False, False),
-            2: anim.CharacterCell('C', 'blue', 'white', False, False),
-            7: anim.CharacterCell('D', '#00FF00', 'white', False, False),
-            8: anim.CharacterCell('E', '#00FF00', 'white', False, False),
-            9: anim.CharacterCell('F', '#00FF00', 'white', False, False),
-            10: anim.CharacterCell('G', '#00FF00', 'white', False, False),
-            11: anim.CharacterCell('H', 'red', 'white', False, False),
-            20: anim.CharacterCell(' ', 'black', 'black', False, False)
+            0: anim.CharacterCell('A', 'red', 'white', False, False, False),
+            1: anim.CharacterCell('B', 'blue', 'white', False, False, False),
+            2: anim.CharacterCell('C', 'blue', 'white', False, False, False),
+            7: anim.CharacterCell('D', '#00FF00', 'white', False, False, False),
+            8: anim.CharacterCell('E', '#00FF00', 'white', False, False, False),
+            9: anim.CharacterCell('F', '#00FF00', 'white', False, False, False),
+            10: anim.CharacterCell('G', '#00FF00', 'white', False, False, False),
+            11: anim.CharacterCell('H', 'red', 'white', False, False, False),
+            20: anim.CharacterCell(' ', 'black', 'black', False, False, False)
         }
 
         with self.subTest(case='Content'):
@@ -146,7 +147,7 @@ class TestAnim(unittest.TestCase):
 
     def test_make_animated_group(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False) for c in 'line{}'.format(i)]
+            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False, False) for c in 'line{}'.format(i)]
             return dict(enumerate(chars))
 
         records = [
@@ -167,7 +168,7 @@ class TestAnim(unittest.TestCase):
 
     def test__render_animation(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False) for c in 'line{}'.format(i)]
+            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False, False) for c in 'line{}'.format(i)]
             return dict(enumerate(chars))
 
         records = [

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -31,18 +31,21 @@ class TestAnim(unittest.TestCase):
             pyte.screens.Char('H', 'red', 'blue', italics=True),
             # Underscore
             pyte.screens.Char('I', 'red', 'blue', underscore=True),
+            # Strikethrough
+            pyte.screens.Char('J', 'red', 'blue', strikethrough=True),
         ]
 
         char_cells = [
-            anim.CharacterCell('A', 'color1', 'color4', False, False, False),
-            anim.CharacterCell('B', 'color4', 'color1', False, False, False),
-            anim.CharacterCell('C', 'color9', 'color4', True, False, False),
-            anim.CharacterCell('D', 'color4', 'color9', True, False, False),
-            anim.CharacterCell('E', 'foreground', 'background', False, False, False),
-            anim.CharacterCell('F', '#008700', '#ABCDEF', False, False, False),
-            anim.CharacterCell('G', 'color10', '#ABCDEF', True, False, False),
-            anim.CharacterCell('H', 'color1', 'color4', False, True, False),
-            anim.CharacterCell('I', 'color1', 'color4', False, False, True),
+            anim.CharacterCell('A', 'color1', 'color4', False, False, False, False),
+            anim.CharacterCell('B', 'color4', 'color1', False, False, False, False),
+            anim.CharacterCell('C', 'color9', 'color4', True, False, False, False),
+            anim.CharacterCell('D', 'color4', 'color9', True, False, False, False),
+            anim.CharacterCell('E', 'foreground', 'background', False, False, False, False),
+            anim.CharacterCell('F', '#008700', '#ABCDEF', False, False, False, False),
+            anim.CharacterCell('G', 'color10', '#ABCDEF', True, False, False, False),
+            anim.CharacterCell('H', 'color1', 'color4', False, True, False, False),
+            anim.CharacterCell('I', 'color1', 'color4', False, False, True, False),
+            anim.CharacterCell('J', 'color1', 'color4', False, False, False, True),
         ]
 
         for pyte_char, cell_char in zip(pyte_chars, char_cells):
@@ -52,16 +55,16 @@ class TestAnim(unittest.TestCase):
     def test__render_line_bg_colors_xml(self):
         cell_width = 8
         screen_line = {
-            0: anim.CharacterCell('A', 'black', 'red', False, False, False),
-            1: anim.CharacterCell('A', 'black', 'red', False, False, False),
-            3: anim.CharacterCell('A', 'black', 'red', False, False, False),
-            4: anim.CharacterCell('A', 'black', 'blue', False, False, False),
-            6: anim.CharacterCell('A', 'black', 'blue', False, False, False),
-            7: anim.CharacterCell('A', 'black', 'blue', False, False, False),
-            8: anim.CharacterCell('A', 'black', 'green', False, False, False),
-            9: anim.CharacterCell('A', 'black', 'red', False, False, False),
-            10: anim.CharacterCell('A', 'black', 'red', False, False, False),
-            11: anim.CharacterCell('A', 'black', '#123456', False, False, False),
+            0: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
+            1: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
+            3: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
+            4: anim.CharacterCell('A', 'black', 'blue', False, False, False, False),
+            6: anim.CharacterCell('A', 'black', 'blue', False, False, False, False),
+            7: anim.CharacterCell('A', 'black', 'blue', False, False, False, False),
+            8: anim.CharacterCell('A', 'black', 'green', False, False, False, False),
+            9: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
+            10: anim.CharacterCell('A', 'black', 'red', False, False, False, False),
+            11: anim.CharacterCell('A', 'black', '#123456', False, False, False, False),
         }
 
         rectangles = anim._render_line_bg_colors(screen_line=screen_line,
@@ -91,15 +94,15 @@ class TestAnim(unittest.TestCase):
 
     def test__render_characters(self):
         screen_line = {
-            0: anim.CharacterCell('A', 'red', 'white', False, False, False),
-            1: anim.CharacterCell('B', 'blue', 'white', False, False, False),
-            2: anim.CharacterCell('C', 'blue', 'white', False, False, False),
-            7: anim.CharacterCell('D', '#00FF00', 'white', False, False, False),
-            8: anim.CharacterCell('E', '#00FF00', 'white', False, False, False),
-            9: anim.CharacterCell('F', '#00FF00', 'white', False, False, False),
-            10: anim.CharacterCell('G', '#00FF00', 'white', False, False, False),
-            11: anim.CharacterCell('H', 'red', 'white', False, False, False),
-            20: anim.CharacterCell(' ', 'black', 'black', False, False, False)
+            0: anim.CharacterCell('A', 'red', 'white', False, False, False, False),
+            1: anim.CharacterCell('B', 'blue', 'white', False, False, False, False),
+            2: anim.CharacterCell('C', 'blue', 'white', False, False, False, False),
+            7: anim.CharacterCell('D', '#00FF00', 'white', False, False, False, False),
+            8: anim.CharacterCell('E', '#00FF00', 'white', False, False, False, False),
+            9: anim.CharacterCell('F', '#00FF00', 'white', False, False, False, False),
+            10: anim.CharacterCell('G', '#00FF00', 'white', False, False, False, False),
+            11: anim.CharacterCell('H', 'red', 'white', False, False, False, False),
+            20: anim.CharacterCell(' ', 'black', 'black', False, False, False, False)
         }
 
         with self.subTest(case='Content'):
@@ -147,7 +150,7 @@ class TestAnim(unittest.TestCase):
 
     def test_make_animated_group(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False, False) for c in 'line{}'.format(i)]
+            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False, False, False) for c in 'line{}'.format(i)]
             return dict(enumerate(chars))
 
         records = [
@@ -168,7 +171,7 @@ class TestAnim(unittest.TestCase):
 
     def test__render_animation(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False, False) for c in 'line{}'.format(i)]
+            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False, False, False) for c in 'line{}'.format(i)]
             return dict(enumerate(chars))
 
         records = [

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -27,16 +27,19 @@ class TestAnim(unittest.TestCase):
             pyte.screens.Char('F', '008700', 'ABCDEF'),
             # Bright and bold
             pyte.screens.Char('G', 'brightgreen', 'ABCDEF', bold=True),
+            # Underscore
+            pyte.screens.Char('H', 'red', 'blue', underscore=True),
         ]
 
         char_cells = [
-            anim.CharacterCell('A', 'color1', 'color4', False),
-            anim.CharacterCell('B', 'color4', 'color1', False),
-            anim.CharacterCell('C', 'color9', 'color4', True),
-            anim.CharacterCell('D', 'color4', 'color9', True),
-            anim.CharacterCell('E', 'foreground', 'background', False),
-            anim.CharacterCell('F', '#008700', '#ABCDEF', False),
-            anim.CharacterCell('G', 'color10', '#ABCDEF', True),
+            anim.CharacterCell('A', 'color1', 'color4', False, False),
+            anim.CharacterCell('B', 'color4', 'color1', False, False),
+            anim.CharacterCell('C', 'color9', 'color4', True, False),
+            anim.CharacterCell('D', 'color4', 'color9', True, False),
+            anim.CharacterCell('E', 'foreground', 'background', False, False),
+            anim.CharacterCell('F', '#008700', '#ABCDEF', False, False),
+            anim.CharacterCell('G', 'color10', '#ABCDEF', True, False),
+            anim.CharacterCell('H', 'color1', 'color4', False, True),
         ]
 
         for pyte_char, cell_char in zip(pyte_chars, char_cells):
@@ -46,16 +49,16 @@ class TestAnim(unittest.TestCase):
     def test__render_line_bg_colors_xml(self):
         cell_width = 8
         screen_line = {
-            0: anim.CharacterCell('A', 'black', 'red', False),
-            1: anim.CharacterCell('A', 'black', 'red', False),
-            3: anim.CharacterCell('A', 'black', 'red', False),
-            4: anim.CharacterCell('A', 'black', 'blue', False),
-            6: anim.CharacterCell('A', 'black', 'blue', False),
-            7: anim.CharacterCell('A', 'black', 'blue', False),
-            8: anim.CharacterCell('A', 'black', 'green', False),
-            9: anim.CharacterCell('A', 'black', 'red', False),
-            10: anim.CharacterCell('A', 'black', 'red', False),
-            11: anim.CharacterCell('A', 'black', '#123456', False),
+            0: anim.CharacterCell('A', 'black', 'red', False, False),
+            1: anim.CharacterCell('A', 'black', 'red', False, False),
+            3: anim.CharacterCell('A', 'black', 'red', False, False),
+            4: anim.CharacterCell('A', 'black', 'blue', False, False),
+            6: anim.CharacterCell('A', 'black', 'blue', False, False),
+            7: anim.CharacterCell('A', 'black', 'blue', False, False),
+            8: anim.CharacterCell('A', 'black', 'green', False, False),
+            9: anim.CharacterCell('A', 'black', 'red', False, False),
+            10: anim.CharacterCell('A', 'black', 'red', False, False),
+            11: anim.CharacterCell('A', 'black', '#123456', False, False),
         }
 
         rectangles = anim._render_line_bg_colors(screen_line=screen_line,
@@ -85,15 +88,15 @@ class TestAnim(unittest.TestCase):
 
     def test__render_characters(self):
         screen_line = {
-            0: anim.CharacterCell('A', 'red', 'white', False),
-            1: anim.CharacterCell('B', 'blue', 'white', False),
-            2: anim.CharacterCell('C', 'blue', 'white', False),
-            7: anim.CharacterCell('D', '#00FF00', 'white', False),
-            8: anim.CharacterCell('E', '#00FF00', 'white', False),
-            9: anim.CharacterCell('F', '#00FF00', 'white', False),
-            10: anim.CharacterCell('G', '#00FF00', 'white', False),
-            11: anim.CharacterCell('H', 'red', 'white', False),
-            20: anim.CharacterCell(' ', 'black', 'black', False)
+            0: anim.CharacterCell('A', 'red', 'white', False, False),
+            1: anim.CharacterCell('B', 'blue', 'white', False, False),
+            2: anim.CharacterCell('C', 'blue', 'white', False, False),
+            7: anim.CharacterCell('D', '#00FF00', 'white', False, False),
+            8: anim.CharacterCell('E', '#00FF00', 'white', False, False),
+            9: anim.CharacterCell('F', '#00FF00', 'white', False, False),
+            10: anim.CharacterCell('G', '#00FF00', 'white', False, False),
+            11: anim.CharacterCell('H', 'red', 'white', False, False),
+            20: anim.CharacterCell(' ', 'black', 'black', False, False)
         }
 
         with self.subTest(case='Content'):
@@ -141,7 +144,7 @@ class TestAnim(unittest.TestCase):
 
     def test_make_animated_group(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False) for c in 'line{}'.format(i)]
+            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False) for c in 'line{}'.format(i)]
             return dict(enumerate(chars))
 
         records = [
@@ -162,7 +165,7 @@ class TestAnim(unittest.TestCase):
 
     def test__render_animation(self):
         def line(i):
-            chars = [anim.CharacterCell(c, '#123456', '#789012', False) for c in 'line{}'.format(i)]
+            chars = [anim.CharacterCell(c, '#123456', '#789012', False, False) for c in 'line{}'.format(i)]
             return dict(enumerate(chars))
 
         records = [

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -36,26 +36,16 @@ class TestAnim(unittest.TestCase):
         ]
 
         char_cells = [
-            anim.CharacterCell('A', 'color1', 'color4',
-                               False, False, False, False),
-            anim.CharacterCell('B', 'color4', 'color1',
-                               False, False, False, False),
-            anim.CharacterCell('C', 'color9', 'color4',
-                               True, False, False, False),
-            anim.CharacterCell('D', 'color4', 'color9',
-                               True, False, False, False),
-            anim.CharacterCell('E', 'foreground', 'background',
-                               False, False, False, False),
-            anim.CharacterCell('F', '#008700', '#ABCDEF',
-                               False, False, False, False),
-            anim.CharacterCell('G', 'color10', '#ABCDEF',
-                               True, False, False, False),
-            anim.CharacterCell('H', 'color1', 'color4',
-                               False, True, False, False),
-            anim.CharacterCell('I', 'color1', 'color4',
-                               False, False, True, False),
-            anim.CharacterCell('J', 'color1', 'color4',
-                               False, False, False, True),
+            anim.CharacterCell('A', 'color1', 'color4'),
+            anim.CharacterCell('B', 'color4', 'color1'),
+            anim.CharacterCell('C', 'color9', 'color4', bold=True),
+            anim.CharacterCell('D', 'color4', 'color9', bold=True),
+            anim.CharacterCell('E', 'foreground', 'background'),
+            anim.CharacterCell('F', '#008700', '#ABCDEF'),
+            anim.CharacterCell('G', 'color10', '#ABCDEF', bold=True),
+            anim.CharacterCell('H', 'color1', 'color4', italics=True),
+            anim.CharacterCell('I', 'color1', 'color4', underscore=True),
+            anim.CharacterCell('J', 'color1', 'color4', strikethrough=True),
         ]
 
         for pyte_char, cell_char in zip(pyte_chars, char_cells):
@@ -65,26 +55,16 @@ class TestAnim(unittest.TestCase):
     def test__render_line_bg_colors_xml(self):
         cell_width = 8
         screen_line = {
-            0: anim.CharacterCell('A', 'black', 'red',
-                                  False, False, False, False),
-            1: anim.CharacterCell('A', 'black', 'red',
-                                  False, False, False, False),
-            3: anim.CharacterCell('A', 'black', 'red',
-                                  False, False, False, False),
-            4: anim.CharacterCell('A', 'black', 'blue',
-                                  False, False, False, False),
-            6: anim.CharacterCell('A', 'black', 'blue',
-                                  False, False, False, False),
-            7: anim.CharacterCell('A', 'black', 'blue',
-                                  False, False, False, False),
-            8: anim.CharacterCell('A', 'black', 'green',
-                                  False, False, False, False),
-            9: anim.CharacterCell('A', 'black', 'red',
-                                  False, False, False, False),
-            10: anim.CharacterCell('A', 'black', 'red',
-                                   False, False, False, False),
-            11: anim.CharacterCell('A', 'black', '#123456',
-                                   False, False, False, False),
+            0: anim.CharacterCell('A', 'black', 'red'),
+            1: anim.CharacterCell('A', 'black', 'red'),
+            3: anim.CharacterCell('A', 'black', 'red'),
+            4: anim.CharacterCell('A', 'black', 'blue'),
+            6: anim.CharacterCell('A', 'black', 'blue'),
+            7: anim.CharacterCell('A', 'black', 'blue'),
+            8: anim.CharacterCell('A', 'black', 'green'),
+            9: anim.CharacterCell('A', 'black', 'red'),
+            10: anim.CharacterCell('A', 'black', 'red'),
+            11: anim.CharacterCell('A', 'black', '#123456'),
         }
 
         rectangles = anim._render_line_bg_colors(screen_line=screen_line,
@@ -114,41 +94,36 @@ class TestAnim(unittest.TestCase):
 
     def test__render_characters(self):
         screen_line = {
-            0: anim.CharacterCell('A', 'red', 'white',
-                                  False, False, False, False),
-            1: anim.CharacterCell('B', 'blue', 'white',
-                                  False, False, False, False),
-            2: anim.CharacterCell('C', 'blue', 'white',
-                                  False, False, False, False),
-            7: anim.CharacterCell('D', '#00FF00', 'white',
-                                  False, False, False, False),
-            8: anim.CharacterCell('E', '#00FF00', 'white',
-                                  False, False, False, False),
-            9: anim.CharacterCell('F', '#00FF00', 'white',
-                                  False, False, False, False),
-            10: anim.CharacterCell('G', '#00FF00', 'white',
-                                   False, False, False, False),
-            11: anim.CharacterCell('H', 'red', 'white',
-                                   False, False, False, False),
-            20: anim.CharacterCell(' ', 'black', 'black',
-                                   False, False, False, False)
+            0: anim.CharacterCell('A', 'red', 'white'),
+            1: anim.CharacterCell('B', 'blue', 'white'),
+            2: anim.CharacterCell('C', 'blue', 'white'),
+            7: anim.CharacterCell('D', '#00FF00', 'white'),
+            8: anim.CharacterCell('E', '#00FF00', 'white'),
+            9: anim.CharacterCell('F', '#00FF00', 'white'),
+            10: anim.CharacterCell('G', '#00FF00', 'white'),
+            20: anim.CharacterCell('H', 'black', 'black', bold=True),
+            30: anim.CharacterCell('I', 'black', 'black', italics=True),
+            40: anim.CharacterCell('J', 'black', 'black', underscore=True),
+            50: anim.CharacterCell('K', 'black', 'black', strikethrough=True),
+            60: anim.CharacterCell('L', 'black', 'black', underscore=True, strikethrough=True),
         }
 
         with self.subTest(case='Content'):
             cell_width = 8
-            texts = anim._render_characters(screen_line, cell_width)
+            texts = {t.text: t for t in anim._render_characters(screen_line, cell_width)}
 
-            sorted_texts = sorted(texts, key=lambda x: x.text)
-            [text_a, text_bc, text_defg, text_h, text_space] = sorted_texts
-            self.assertEqual(text_a.text, 'A')
-            self.assertEqual(text_a.attrib['class'], 'red')
-            self.assertEqual(text_a.attrib['x'], '0')
-            self.assertEqual(text_bc.text, 'BC')
-            self.assertEqual(text_bc.attrib['class'], 'blue')
-            self.assertEqual(text_bc.attrib['x'], '8')
-            self.assertEqual(text_defg.text, 'DEFG')
-            self.assertEqual(text_defg.attrib['fill'], '#00FF00')
-            self.assertEqual(text_defg.attrib['x'], '56')
+            self.assertEqual(texts['A'].attrib['class'], 'red')
+            self.assertEqual(texts['A'].attrib['x'], '0')
+            self.assertEqual(texts['BC'].attrib['class'], 'blue')
+            self.assertEqual(texts['BC'].attrib['x'], '8')
+            self.assertEqual(texts['DEFG'].attrib['fill'], '#00FF00')
+            self.assertEqual(texts['DEFG'].attrib['x'], '56')
+            self.assertEqual(texts['H'].attrib['font-weight'], 'bold')
+            self.assertEqual(texts['I'].attrib['font-style'], 'italic')
+            self.assertIn('underline', texts['J'].attrib['text-decoration'].split())
+            self.assertIn('line-through', texts['K'].attrib['text-decoration'].split())
+            self.assertIn('underline', texts['L'].attrib['text-decoration'].split())
+            self.assertIn('line-through', texts['L'].attrib['text-decoration'].split())
 
     def test_ConsecutiveWithSameAttributes(self):
         testClass = namedtuple('testClass', ['field1', 'field2'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,6 +20,7 @@ SHELL_COMMANDS = [
     'echo -e "\\033[1mbold\\033[0m"\r\n',
     'echo -e "\\033[3mitalics\\033[0m"\r\n',
     'echo -e "\\033[4munderscore\\033[0m"\r\n',
+    'echo -e "\\033[4mstrikethrough\\033[0m"\r\n',
     'exit;\r\n'
 ]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,6 +19,7 @@ SHELL_COMMANDS = [
     'echo -e "\\033[1;41mbright red bg\\033[0m"\r\n',
     'echo -e "\\033[1mbold\\033[0m"\r\n',
     'echo -e "\\033[3mitalics\\033[0m"\r\n',
+    'echo -e "\\033[4munderscore\\033[0m"\r\n',
     'exit;\r\n'
 ]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,7 +20,7 @@ SHELL_COMMANDS = [
     'echo -e "\\033[1mbold\\033[0m"\r\n',
     'echo -e "\\033[3mitalics\\033[0m"\r\n',
     'echo -e "\\033[4munderscore\\033[0m"\r\n',
-    'echo -e "\\033[4mstrikethrough\\033[0m"\r\n',
+    'echo -e "\\033[9mstrikethrough\\033[0m"\r\n',
     'exit;\r\n'
 ]
 


### PR DESCRIPTION
I added support for underlined and strikethrough text. pyte already supported it.

Also, I split the lines I added at 80 chars. I'm not sure if this is how you'd like them to be; it is a bit inconsistent in the rest of the code.