### PR TITLE
Adds vertical spacing measured in character cells between successive frames

### DIFF
--- a/termtosvg/anim.py
+++ b/termtosvg/anim.py
@@ -37,6 +37,10 @@ BG_RECT_TAG = etree.Element('rect', _BG_RECT_TAG_ATTRIBUTES)
 CELL_WIDTH = 8
 CELL_HEIGHT = 17
 
+# The number of character cells to leave when placing successive frames
+# so content does not bleed into adjacent frames
+FRAME_CELL_SPACING = 1
+
 # XML namespaces
 SVG_NS = 'http://www.w3.org/2000/svg'
 TERMTOSVG_NS = 'https://github.com/nbedos/termtosvg'
@@ -201,7 +205,7 @@ def _render_animation(screen_height, frames, root, cell_width, cell_height):
     timings = {}
     animation_duration = None
     for frame_count, frame in enumerate(frames):
-        offset = frame_count * screen_height * cell_height
+        offset = frame_count * (screen_height + FRAME_CELL_SPACING) * cell_height
         frame_group, frame_definitions = _render_timed_frame(
             offset=offset,
             buffer=frame.buffer,


### PR DESCRIPTION
This PR address issue #100 which occurs when using CSS animation. Content from a frame – in particular the cursor – can bleed into the bottom of the current frame. I think this is happening because the cursor is slightly more than one character cell high, and there is no free space between the frame of the animation as they are laid out in space.

This commit introduces one character cell of vertical space between successive frame when placing the animation frames, which avoids this problem.